### PR TITLE
Bugfix 2.0.x smith3 d warningscleanup

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -1305,7 +1305,6 @@ void HMI_Move_Z() {
   }
 
   void HMI_Move_E_Refuel() {
-    static float last_E_scale = 0;
     ENCODER_DiffState encoder_diffState = Encoder_ReceiveAnalyze();
     if (encoder_diffState != ENCODER_DIFF_NO) {
       if (Apply_Encoder(encoder_diffState, HMI_ValueStruct.Move_E_scale)) {
@@ -2541,7 +2540,7 @@ void HMI_Prepare() {
       case PREPARE_CASE_HOME: // Homing
         checkkey = Last_Prepare;
         index_prepare = MROWS;
-        gcode.process_subcommands_now( PSTR("M220 S100"));
+        gcode.process_subcommands_now_P( PSTR("M220 S100"));
         queue.inject_P(PSTR("G28")); // G28 will set home_flag
         Popup_Window_Home();
         break;
@@ -2564,15 +2563,15 @@ void HMI_Prepare() {
           select_ztool.reset();
           Popup_Window_Home(false);
           DWIN_UpdateLCD();
-          gcode.process_subcommands_now( PSTR("M220 S100"));
-          gcode.process_subcommands_now( PSTR("M420 Z0"));
-          gcode.process_subcommands_now( PSTR("G28"));
-          gcode.process_subcommands_now( PSTR("G92 E0"));
+          gcode.process_subcommands_now_P( PSTR("M220 S100"));
+          gcode.process_subcommands_now_P( PSTR("M420 Z0"));
+          gcode.process_subcommands_now_P( PSTR("G28"));
+          gcode.process_subcommands_now_P( PSTR("G92 E0"));
           //gcode.process_subcommands_now_P( PSTR("G1 F4000 Z10"));
           //gcode.process_subcommands_now_P( PSTR("G1 F4000 X145 Y116"));
           gcode.process_subcommands_now_P( PSTR("G1 F60 Z0"));
           gcode.process_subcommands_now_P( PSTR("M211 S0"));
-          gcode.process_subcommands_now( PSTR("M220 S100"));
+          gcode.process_subcommands_now_P( PSTR("M220 S100"));
           planner.synchronize();
           current_position.e = HMI_ValueStruct.Move_E_scale = 0;
           //dwin_zoffset = TERN(HAS_ONESTEP_LEVELING, probe.offset.z, 0);
@@ -2586,9 +2585,9 @@ void HMI_Prepare() {
         select_aux.reset();
         Popup_Window_Home(false);
         DWIN_UpdateLCD();
-        gcode.process_subcommands_now( PSTR("M220 S100"));
-        gcode.process_subcommands_now( PSTR("G28"));
-        gcode.process_subcommands_now( PSTR("G92 E0"));
+        gcode.process_subcommands_now_P( PSTR("M220 S100"));
+        gcode.process_subcommands_now_P( PSTR("G28"));
+        gcode.process_subcommands_now_P( PSTR("G92 E0"));
         planner.synchronize();
         current_position.e = HMI_ValueStruct.Move_E_scale = 0;
         Draw_AUX_Menu();
@@ -2809,7 +2808,7 @@ void HMI_Control() {
   void HMI_Leveling() {
     Popup_Window_Leveling();
     DWIN_UpdateLCD();
-    gcode.process_subcommands_now( PSTR("M220 S100"));
+    gcode.process_subcommands_now_P( PSTR("M220 S100"));
     queue.inject_P(PSTR("G28O\nG29"));
   }
 
@@ -3351,22 +3350,22 @@ void HMI_AUX() {
          index_aux = MROWS;
          //Popup_Window_Aux();
          //DWIN_UpdateLCD();
-        gcode.process_subcommands_now( PSTR("G1 F4000"));
-        gcode.process_subcommands_now( PSTR("G1 Z10"));
-        gcode.process_subcommands_now( PSTR("G1 X20 Y20"));
-        gcode.process_subcommands_now( PSTR("G1 F300 Z0"));
-        gcode.process_subcommands_now( PSTR("M220 S100"));
+        gcode.process_subcommands_now_P( PSTR("G1 F4000"));
+        gcode.process_subcommands_now_P( PSTR("G1 Z10"));
+        gcode.process_subcommands_now_P( PSTR("G1 X20 Y20"));
+        gcode.process_subcommands_now_P( PSTR("G1 F300 Z0"));
+        gcode.process_subcommands_now_P( PSTR("M220 S100"));
         
         planner.synchronize();
         break;
       case 2: // top left
        // checkkey = Move2;
        index_aux = MROWS;
-        gcode.process_subcommands_now( PSTR("G1 F4000"));
-        gcode.process_subcommands_now( PSTR("G1 Z10"));
-        gcode.process_subcommands_now( PSTR("G1 X20 Y200"));
-        gcode.process_subcommands_now( PSTR("G1 F300 Z0"));
-        gcode.process_subcommands_now( PSTR("M220 S100"));
+        gcode.process_subcommands_now_P( PSTR("G1 F4000"));
+        gcode.process_subcommands_now_P( PSTR("G1 Z10"));
+        gcode.process_subcommands_now_P( PSTR("G1 X20 Y200"));
+        gcode.process_subcommands_now_P( PSTR("G1 F300 Z0"));
+        gcode.process_subcommands_now_P( PSTR("M220 S100"));
         planner.synchronize();
         break;
       case 3: // top right
@@ -3376,7 +3375,7 @@ void HMI_AUX() {
         gcode.process_subcommands_now_P( PSTR("G1 Z10"));
         gcode.process_subcommands_now_P( PSTR("G1 X200 Y200"));
         gcode.process_subcommands_now_P( PSTR("G1 F300 Z0"));
-        gcode.process_subcommands_now( PSTR("M220 S100"));
+        gcode.process_subcommands_now_P( PSTR("M220 S100"));
         planner.synchronize();
         break;
       case 4: // bottom right
@@ -3386,7 +3385,7 @@ void HMI_AUX() {
         gcode.process_subcommands_now_P( PSTR("G1 Z10"));
         gcode.process_subcommands_now_P( PSTR("G1 X200 Y20"));
         gcode.process_subcommands_now_P( PSTR("G1 F300 Z0"));
-        gcode.process_subcommands_now( PSTR("M220 S100"));
+        gcode.process_subcommands_now_P( PSTR("M220 S100"));
       planner.synchronize();
          
         break;
@@ -3397,7 +3396,7 @@ void HMI_AUX() {
         gcode.process_subcommands_now_P( PSTR("G1 Z10"));
         gcode.process_subcommands_now_P( PSTR("G1 X145 Y116"));
         gcode.process_subcommands_now_P( PSTR("G1 F300 Z0"));
-        gcode.process_subcommands_now( PSTR("M220 S100"));
+        gcode.process_subcommands_now_P( PSTR("M220 S100"));
         planner.synchronize();
         break;
       default:
@@ -3425,7 +3424,6 @@ void HMI_Refuel(void){
   #endif
 
   char gcode_string[80];
-  static float last_E_scale = 0;
   if (encoder_diffState == ENCODER_DIFF_CW) {
     if (select_refuel.inc(4)) Move_Highlight(1, select_refuel.now);
   }

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -84,6 +84,8 @@
 #ifdef Z_MIN_PROBE_PIN
   #undef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN                     PB1   // BLTouch IN
+#else
+  #define Z_MIN_PROBE_PIN                     PB1   // BLTouch IN
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -81,7 +81,10 @@
 #define Y_STOP_PIN                          PA6
 #define Z_STOP_PIN                          PA7
 
-#define Z_MIN_PROBE_PIN                     PB1   // BLTouch IN
+#ifdef Z_MIN_PROBE_PIN
+  #undef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                     PB1   // BLTouch IN
+#endif
 
 //
 // Filament Runout Sensor


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

I have made some small changes to the code to remove the compiler warnings.  This included the following,

- couple of unused variables
- redefinition of compile constant without calling undef first
- usage of wrong function for running commands

### Benefits

<!-- What does this fix or improve? -->

Removes warnings from compilation (which is always a good thing), except for one relating to the usage of "auto" keyword but I have left that as it appears in other builds of Marlin that I have looked at to compare.

Potentially more stable code.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

No changes to configurations.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->

No issues found as a result of these compiler warnings, other than the warnings themselves.
